### PR TITLE
Consolidate analytics.js dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,8 @@
 machine:
   node:
     version: 4
+  timezone:
+    America/Los_Angeles
   environment:
     NPM_CONFIG_PROGRESS: false
     NPM_CONFIG_SPIN: false

--- a/karma.conf.ci.js
+++ b/karma.conf.ci.js
@@ -64,6 +64,11 @@ var customLaunchers = {
   }
 };
 
+// These tests rely on the timezone being US/Pacific
+Object.keys(customLaunchers).forEach(function(key) {
+  customLaunchers[key].timeZone = 'Los Angeles';
+});
+
 module.exports = function(config) {
   baseConfig(config);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "homepage": "https://github.com/segmentio/new-date#readme",
   "dependencies": {
     "@segment/isodate": "1.0.2",
-    "is": "0.2.6"
+    "is": "^3.1.0"
   },
   "devDependencies": {
     "@segment/eslint-config": "^3.1.1",
@@ -31,7 +31,7 @@
     "browserify-istanbul": "^2.0.0",
     "eslint": "^2.9.0",
     "istanbul": "^0.4.3",
-    "karma": "^0.13.22",
+    "karma": "^1.1.0",
     "karma-browserify": "^5.0.4",
     "karma-chrome-launcher": "^1.0.1",
     "karma-coverage": "^1.0.0",


### PR DESCRIPTION
This gets rid of a dependency of multiple versions of the `is` library. Consequently, it also fixes support for IE8 since the 0.2.6 version doesn't have https://github.com/enricomarino/is/pull/5